### PR TITLE
 ColorCameraExtrinsicsToROS tool

### DIFF
--- a/PhoXiAPI/ColorCameraExtrinsicsToROS/CMakeLists.txt
+++ b/PhoXiAPI/ColorCameraExtrinsicsToROS/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required (VERSION 3.10)
+
+if(POLICY CMP0054)
+    cmake_policy(SET CMP0054 NEW)
+endif()
+
+project(ColorCameraExtrinsicsToROS)
+
+set(CMAKE_RELEASE_POSTFIX "_Release")
+set(CMAKE_DEBUG_POSTFIX "_Debug")
+
+find_package (Eigen3 3.3 REQUIRED NO_MODULE)
+
+if (UNIX AND NOT APPLE)
+    add_compile_options(-std=c++1y)
+    add_compile_options(-pthread)
+endif(UNIX AND NOT APPLE)
+
+set(Files
+    ${ColorCameraExtrinsicsToROS_SOURCE_DIR}/ColorCameraExtrinsicsToROS.cpp
+    ${ColorCameraExtrinsicsToROS_SOURCE_DIR}/ReadMe.txt
+)
+
+add_executable(ColorCameraExtrinsicsToROS
+    ${Files}
+)
+
+if (NOT PHO_API_CMAKE_CONFIG_PATH)
+    set(PHO_API_CMAKE_CONFIG_PATH "$ENV{PHOXI_CONTROL_PATH}")
+endif()
+
+find_package(PhoXi REQUIRED CONFIG PATHS "${PHO_API_CMAKE_CONFIG_PATH}")
+
+target_link_libraries(ColorCameraExtrinsicsToROS
+    ${PHOXI_LIBRARY}
+    $<$<PLATFORM_ID:Linux>:rt>
+    Eigen3::Eigen
+)
+
+if(MSVC)
+    add_custom_command(TARGET ColorCameraExtrinsicsToROS POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            $<$<CONFIG:Release>:${PHOXI_DLL_RELEASE}>
+            $<$<CONFIG:Debug>:${PHOXI_DLL_DEBUG}>
+            $<TARGET_FILE_DIR:ColorCameraExtrinsicsToROS>
+    )
+endif()
+
+target_include_directories(ColorCameraExtrinsicsToROS PUBLIC 
+    ${PHOXI_INCLUDE_DIRS}
+)

--- a/PhoXiAPI/ColorCameraExtrinsicsToROS/ColorCameraExtrinsicsToROS.cpp
+++ b/PhoXiAPI/ColorCameraExtrinsicsToROS/ColorCameraExtrinsicsToROS.cpp
@@ -208,6 +208,7 @@ void printROSExtrinsics(pho::api::PPhoXi& PhoXiDevice)
 
     std::cout << "<launch>" << std::endl;
 
+    //static_transform_publisher for ColorCamera/Range
     std::cout << "  <node pkg=\"tf2_ros\" "
               <<         "type=\"static_transform_publisher\" "
               <<         "name=\"" << node_name <<  "\" "

--- a/PhoXiAPI/ColorCameraExtrinsicsToROS/ColorCameraExtrinsicsToROS.cpp
+++ b/PhoXiAPI/ColorCameraExtrinsicsToROS/ColorCameraExtrinsicsToROS.cpp
@@ -1,0 +1,226 @@
+/*
+* Photoneo's API Example - ColorCameraCalibrationToROS.cpp
+* Prints ColorCamera calibration parameters in ROS compatible yaml format.
+* This is calibration for raw RGB image respecting currently set resolution.
+* Note that this is different from device computed RGB texture.
+*
+* Modified from ExtendRobotics's FrameCalibrationToROS
+*
+* Mofification Contributors:
+* - Bartosz Meglicki <bartosz.meglicki@extendrobotics.com> (2023)
+*/
+
+#include <vector>
+#include <string>
+#include <iostream>
+#include <sstream>
+
+#include <eigen3/Eigen/Geometry>
+
+#include "PhoXi.h"
+
+//Print out list of device info to standard output
+void printDeviceInfoList(const std::vector<pho::api::PhoXiDeviceInformation> &DeviceList);
+//Print out device info to standard output
+void printDeviceInfo(const pho::api::PhoXiDeviceInformation &DeviceInfo);
+//Print out calibration parameters
+void printFrameCalibParams(pho::api::PPhoXi &PhoXiDevice);
+//Print out scanning volume information
+
+Eigen::Quaterniond rotationAxisToQuaternion(const pho::api::Point3_64f &X, const pho::api::Point3_64f &Y, const pho::api::Point3_64f &Z)
+{
+  Eigen::Matrix3d m;
+  
+  // We need to be careful about the order, as
+  // Photoneo vectors form column major rotation matrix
+  // while Eigen::Matrix3f expects row-major
+  m << X.x, Y.x, Z.x,
+       X.y, Y.y, Z.y,
+       X.z, Y.z, Z.z;
+
+  Eigen::Quaterniond q(m);
+
+  return q;
+}
+
+Eigen::Quaterniond eulerToQuaternion(double roll, double pitch, double yaw)
+{
+    Eigen::AngleAxisd rollAngle(roll, Eigen::Vector3d::UnitX());
+    Eigen::AngleAxisd pitchAngle(pitch, Eigen::Vector3d::UnitY());
+    Eigen::AngleAxisd yawAngle(yaw, Eigen::Vector3d::UnitZ());
+
+    Eigen::Quaterniond q = yawAngle * pitchAngle * rollAngle;
+    return q;  
+}
+
+int main(int argc, char *argv[])
+{
+    pho::api::PhoXiFactory Factory;
+
+    //Check if the PhoXi Control Software is running
+    if (!Factory.isPhoXiControlRunning())
+    {
+        std::cerr << "PhoXi Control Software is not running" << std::endl;
+        return 0;
+    }
+
+    //Get List of available devices on the network
+    std::vector <pho::api::PhoXiDeviceInformation> DeviceList = Factory.GetDeviceList();
+    if (DeviceList.empty())
+    {
+        std::cerr << "PhoXi Factory has found 0 devices" << std::endl;
+        return 0;
+    }
+    printDeviceInfoList(DeviceList);
+
+    //Try to connect device opened in PhoXi Control, if any
+    pho::api::PPhoXi PhoXiDevice = Factory.CreateAndConnectFirstAttached();
+    if (PhoXiDevice)
+    {
+        std::cout << "# You have already PhoXi device opened in PhoXi Control, the API Example is connected to device: "
+            << (std::string) PhoXiDevice->HardwareIdentification << std::endl;
+    }
+    else
+    {
+        std::cout << "# You have no PhoXi device opened in PhoXi Control, the API Example will try to connect to first device in device list" << std::endl;
+        PhoXiDevice = Factory.CreateAndConnect(DeviceList.front().HWIdentification);
+    }
+
+    //Check if device was created
+    if (!PhoXiDevice)
+    {
+        std::cerr << "Your device was not created!" << std::endl;
+        return 0;
+    }
+
+    //Check if device is connected
+    if (!PhoXiDevice->isConnected())
+    {
+        std::cerr << "Your device is not connected" << std::endl;
+        return 0;
+    }
+
+    std::cout << std::endl;
+
+    //Print out calibration parameters from the frame
+    printFrameCalibParams(PhoXiDevice);
+
+    //Disconnect PhoXi device
+    PhoXiDevice->Disconnect();
+    return 0;
+}
+
+void printDeviceInfoList(const std::vector<pho::api::PhoXiDeviceInformation> &DeviceList)
+{
+    for (std::size_t i = 0; i < DeviceList.size(); ++i)
+    {
+        std::cout << "# Device: " << i << std::endl;
+        printDeviceInfo(DeviceList[i]);
+    }
+}
+
+void printDeviceInfo(const pho::api::PhoXiDeviceInformation &DeviceInfo)
+{
+    std::cout << "#  Name:                    " << DeviceInfo.Name << std::endl;
+    std::cout << "#  Hardware Identification: " << DeviceInfo.HWIdentification << std::endl;
+    std::cout << "#  Type:                    " << std::string(DeviceInfo.Type) << std::endl;
+    std::cout << "#  Firmware version:        " << DeviceInfo.FirmwareVersion << std::endl;
+    std::cout << "#  Variant:                 " << DeviceInfo.Variant << std::endl;
+    std::cout << "#  IsFileCamera:            " << (DeviceInfo.IsFileCamera ? "Yes" : "No") << std::endl;
+    std::cout << "#  Feature-Alpha:           " << (DeviceInfo.CheckFeature("Alpha") ? "Yes" : "No") << std::endl;
+    std::cout << "#  Feature-Color:           " << (DeviceInfo.CheckFeature("Color") ? "Yes" : "No") << std::endl;
+    std::cout << "#  Status:                  "
+        << (DeviceInfo.Status.Attached ? "Attached to PhoXi Control. " : "Not Attached to PhoXi Control. ")
+        << (DeviceInfo.Status.Ready ? "Ready to connect" : "Occupied")
+        << std::endl << std::endl;
+}
+
+void printVector(const std::string &name, const pho::api::Point3_64f &vector)
+{
+    std::cout << "# " << name << ": ["
+        << vector.x << "; "
+        << vector.y << "; "
+        << vector.z << "]"
+        << std::endl;
+}
+
+
+void printFrameCalibParams(pho::api::PPhoXi& PhoXiDevice)
+{
+    if (!PhoXiDevice->isAcquiring())
+    {
+        PhoXiDevice->StartAcquisition();
+    }
+    int FrameID = PhoXiDevice->TriggerFrame();
+    if (FrameID < 0)
+    {
+        //If negative number is returned trigger was unsuccessful
+        std::cerr << "Trigger was unsuccessful! code=" << FrameID << std::endl;
+        return;
+    }
+
+    pho::api::PFrame Frame = PhoXiDevice->GetSpecificFrame(FrameID);
+
+    if(!Frame)
+    {
+        std::cerr << "Failed to retrieve the frame!" << std::endl;
+        return;
+    }
+
+    const pho::api::TextureRGB16 &ColorFrame = Frame->ColorCameraImage;
+
+    if(ColorFrame.Empty())
+    {
+        std::cerr << "Failed to retrieve the color camera image!" << std::endl
+                  << "Make sure that ColorCameraImage transfer is enabled in PhoXiControl" << std::endl
+                  << "Make sure that appriopriate settings for color camera are set" << std::endl;
+        return;
+    }
+
+    std::cout << "# ColorCameraImage (raw RGB, this is not depth aligned RGB texture!)" << std::endl;
+    std::cout << "# ColorCameraScale: " << Frame->Info.ColorCameraScale.Width << "x" << Frame->Info.ColorCameraScale.Height << std::endl;
+    printVector("3D sensor position", Frame->Info.SensorPosition);
+    printVector("3D sensor X axis", Frame->Info.SensorXAxis);
+    printVector("3D sensor Y axis", Frame->Info.SensorYAxis);    
+    printVector("3D sensor Z axis", Frame->Info.SensorZAxis);        
+
+    printVector("color camera position", Frame->Info.ColorCameraPosition);
+    printVector("color camera X axis", Frame->Info.ColorCameraXAxis);
+    printVector("color camera Y axis", Frame->Info.ColorCameraYAxis);    
+    printVector("color camera Z axis", Frame->Info.ColorCameraZAxis);        
+
+    Eigen::Quaterniond quaternion_optical = eulerToQuaternion(-M_PI / 2.0, 0.0, -M_PI / 2.0);
+    Eigen::Quaterniond Q = rotationAxisToQuaternion(Frame->Info.ColorCameraXAxis, Frame->Info.ColorCameraYAxis, Frame->Info.ColorCameraZAxis);
+    //Q = quaternion_optical * Q * quaternion_optical.inverse();
+
+
+    std::string parent = "color_camera_frame";
+    std::string child = "range_frame";
+
+    std::string parent_optical = "color_camera_optical_frame";
+    std::string child_optical = "range_optical_frame";
+
+    int period_in_ms = 100;
+
+    auto T = Frame->Info.ColorCameraPosition;
+
+    //ROS uses meteres, Photoneo uses mm
+    const double MM_TO_M = 0.001;
+
+    std::cout << "rosrun tf static_transform_publisher "
+              << T.x * MM_TO_M << " " << T.y * MM_TO_M << " " << T.z * MM_TO_M << " "
+              << Q.x() << " " << Q.y() << " " << Q.z() << " " << Q.w() << " "
+              << child_optical << " " << parent_optical << " " << period_in_ms << std::endl; 
+
+/*              
+    std::cout << "rosrun tf static_transform_publisher "
+              << 0.0 << " " << 0.0 << " " << 0.0 << " "
+              << quaternion_optical.x() << " " << quaternion_optical.y() << " " << quaternion_optical.z() << " " << quaternion_optical.w() << " "
+              << child << " " << child_optical << " " << period_in_ms << std::endl; 
+
+    std::cout << "rosrun tf static_transform_publisher "
+              << 0.0 << " " << 0.0 << " " << 0.0 << " "
+              << quaternion_optical.x() << " " << quaternion_optical.y() << " " << quaternion_optical.z() << " " << quaternion_optical.w() << " "
+              << parent << " " << parent_optical << " " << period_in_ms << std::endl; 
+*/
+}

--- a/PhoXiAPI/ColorCameraExtrinsicsToROS/ReadMe.txt
+++ b/PhoXiAPI/ColorCameraExtrinsicsToROS/ReadMe.txt
@@ -1,0 +1,36 @@
+========================================================================
+    CONSOLE APPLICATION : ColorCameraCalibrationToROS Project Overview
+========================================================================
+
+This is a simple application that prints out ColorCamera ROS compatibe yaml frame calibration.
+This is calibration for raw RGB image respecting currently set color resolution.
+Note that this is different from device computed RGB texture.
+
+You will learn how to:
+
+* obtain ROS compatible ColorCamera calibration file
+
+How to build:
+
+1. Copy ColorCameraCalibrationToROS folder to a location with Read and Write
+   permissions (using the name <source>)
+2. Open CMake
+   2.1. Set Source code to <source>
+   2.2. Set Binaries to <source>/_build or any other writable location
+   2.3. Click Configure and Generate
+3. Build project
+
+How to use:
+1. Set camera parameters (ideally with ROS driver)
+2. Run PhoXiControl
+   2.1. Connect to a scanner
+   2.2. Make sure `Structure->ColorCameraImage` transfer is enabled
+   2.3. Make sure `ColorSettings->Resolution` is as desired
+3. Run ColorCameraCalibrationToROS application and redirect output to yaml file
+  3.1 e.g. `./ColorCameraCalibrationToROS > MyColorCalibration.yaml`
+
+The application will print out frame level calibration params of ColorCamera of the connected scanner.
+If not connected to any scanner, it will automatically connect to the first
+in PhoXiControl.
+
+/////////////////////////////////////////////////////////////////////////////

--- a/PhoXiAPI/ColorCameraExtrinsicsToROS/ReadMe.txt
+++ b/PhoXiAPI/ColorCameraExtrinsicsToROS/ReadMe.txt
@@ -30,7 +30,7 @@ How to use:
    2.1. Connect to a scanner
    2.2. Make sure `Structure->ColorCameraImage` transfer is enabled
 3. Run ColorCameraExtrinsicsToROS application and redirect output to launch file
-  3.1 e.g. `./ColorCameraExtrinsicsToROS > MyColorCameraRangeExtrinsics.yaml`
+  3.1 e.g. `./ColorCameraExtrinsicsToROS > MyColorCameraRangeExtrinsics.launch`
 
 The application will print out launchfile publishing ColorCamera/Range extrinsics of the connected scanner.
 If not connected to any scanner, it will automatically connect to the first

--- a/PhoXiAPI/ColorCameraExtrinsicsToROS/ReadMe.txt
+++ b/PhoXiAPI/ColorCameraExtrinsicsToROS/ReadMe.txt
@@ -1,18 +1,22 @@
 ========================================================================
-    CONSOLE APPLICATION : ColorCameraCalibrationToROS Project Overview
+    CONSOLE APPLICATION : ColorCameraExtrinsicsToROS Project Overview
 ========================================================================
 
-This is a simple application that prints out ColorCamera ROS compatibe yaml frame calibration.
-This is calibration for raw RGB image respecting currently set color resolution.
-Note that this is different from device computed RGB texture.
+This is a simple application that prints ColorCamera/Range extrinsics
+in the form of ROS launchfile with static_transform_publisher.
+
+Those are extrinsics between raw RGB image and depth.
+
+Note that this is different from device computed RGB texture which is aligned to depth
+and extrinsics would be identity in such case.
 
 You will learn how to:
 
-* obtain ROS compatible ColorCamera calibration file
+* obtain ROS compatible launchfile publishing ColorCamera/Range extrinsics.
 
 How to build:
 
-1. Copy ColorCameraCalibrationToROS folder to a location with Read and Write
+1. Copy ColorCameraExtrinsicsToROS folder to a location with Read and Write
    permissions (using the name <source>)
 2. Open CMake
    2.1. Set Source code to <source>
@@ -25,11 +29,10 @@ How to use:
 2. Run PhoXiControl
    2.1. Connect to a scanner
    2.2. Make sure `Structure->ColorCameraImage` transfer is enabled
-   2.3. Make sure `ColorSettings->Resolution` is as desired
-3. Run ColorCameraCalibrationToROS application and redirect output to yaml file
-  3.1 e.g. `./ColorCameraCalibrationToROS > MyColorCalibration.yaml`
+3. Run ColorCameraExtrinsicsToROS application and redirect output to launch file
+  3.1 e.g. `./ColorCameraExtrinsicsToROS > MyColorCameraRangeExtrinsics.yaml`
 
-The application will print out frame level calibration params of ColorCamera of the connected scanner.
+The application will print out launchfile publishing ColorCamera/Range extrinsics of the connected scanner.
 If not connected to any scanner, it will automatically connect to the first
 in PhoXiControl.
 


### PR DESCRIPTION
# Overview

Small tool to dump color camera / depth extrinsics in ROS compatible format.

It generates small launchfile with `static_transform_publisher`

# Note

Note that this is different from device computed color texture
- which is aligned to depth
- extrinsics would be identity in such case

# Usage

Typical
- set camera parameters (e.g. ROS driver)
  - don't forget to enable `ColorCamera` component and set desired resolution
- Start `PhoXi Control` 
- Connect to the camera

```bash
./ColorCameraExtrinsicsToROS > MyColorCameraRangeExtrinsics.launch
```

Then you would include/run generated launchfile.

```bash
roslaunch ./MyColorCameraRangeExtrinsics.launch
```

# Sample output

```xml
<?xml version="1.0" encoding="utf-8"?>

<!--
# Device: 0
#  Name:                    MotionCam-3D-TRD-058
#  Hardware Identification: TRD-058
#  Type:                    MotionCam-3D
#  Firmware version:        1.10.1
#  Variant:                 M+
#  IsFileCamera:            No
#  Feature-Alpha:           No
#  Feature-Color:           Yes
#  Status:                  Attached to PhoXi Control. Ready to connect

# Device: 1
#  Name:                    basic-example
#  Hardware Identification: InstalledExamples-basic-example
#  Type:                    PhoXi3DScan
#  Firmware version:        
#  Variant:                 
#  IsFileCamera:            Yes
#  Feature-Alpha:           No
#  Feature-Color:           No
#  Status:                  Not Attached to PhoXi Control. Ready to connect

# Device: 2
#  Name:                    color-example
#  Hardware Identification: InstalledExamples-color-example
#  Type:                    MotionCam-3D
#  Firmware version:        
#  Variant:                 
#  IsFileCamera:            Yes
#  Feature-Alpha:           No
#  Feature-Color:           Yes
#  Status:                  Not Attached to PhoXi Control. Ready to connect

# You have already PhoXi device opened in PhoXi Control, the API Example is connected to device: TRD-058

# ColorCameraImage (raw RGB, this is not depth aligned RGB texture!)
# ColorCameraScale: 0.5x0.5

# 3D sensor should be [0,0,0] with identity rotation (frame of reference)
# otherwise this tool will not generate correct extrinsics
# 3D sensor position: [0; 0; 0]
# 3D sensor X axis: [1; 0; 0]
# 3D sensor Y axis: [0; 1; 0]
# 3D sensor Z axis: [0; 0; 1]

# color camera position: [-285.575; 0.348021; -2.64781]
# color camera X axis: [0.999758; -0.021911; -0.00175325]
# color camera Y axis: [0.0219171; 0.999753; 0.00358584]
# color camera Z axis: [0.00167425; -0.0036234; 0.999992]
-->
<launch>
  <node pkg="tf2_ros" type="static_transform_publisher" name="range_color_camera_link_broadcaster" args="-0.285575 0.000348021 -0.00264781 0.00180242 0.000856928 -0.0109577 0.999938 range_optical_frame color_camera_optical_frame" />
</launch>
```

# Visual Example

```bash
roslaunch ./MyColorCameraRangeExtrinsics.launch
```

1. `rviz` -> Add -> TF 
2. Fixed Frame -> `range_optical_frame`

![image](https://github.com/Extend-Robotics/photoneo-cpp-examples/assets/9095769/55e23a8d-dc34-41d5-9c37-e79e36042345)

# Implementation Note

It might be better to implement it by pulling global calibration data with extrinsics for raw ColorCamera.

With current implementation we depend on:
- ColorCamera output enabled
- 3D sensor set as frame of reference.
